### PR TITLE
Reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ ADD . /tmp/src/
 
 RUN cd /tmp/src && sh gradlew build -Dorg.gradle.daemon=false
 
-RUN cp -a  /tmp/src/build/libs/springboots2idemo*.jar /deployments/springboots2idemo.jar
+RUN ln -s /tmp/src/build/libs/springboots2idemo*.jar /deployments/springboots2idemo.jar


### PR DESCRIPTION
Prevents trivys `no space left on device` issue if `/tmp` has only 1GB