### PR TITLE
Add trailing slash to pod endpoint

### DIFF
--- a/src/main/java/ch/appuio/techlab/controller/PodRestController.java
+++ b/src/main/java/ch/appuio/techlab/controller/PodRestController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/pod/")
+@RequestMapping({"/pod", "/pod/"})
 public class PodRestController {
 	
 	@RequestMapping(method = RequestMethod.GET)

--- a/src/main/java/ch/appuio/techlab/controller/PodRestController.java
+++ b/src/main/java/ch/appuio/techlab/controller/PodRestController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/pod")
+@RequestMapping("/pod/")
 public class PodRestController {
 	
 	@RequestMapping(method = RequestMethod.GET)


### PR DESCRIPTION
[The acend Kubernetes Basics training](https://github.com/acend/kubernetes-basics-training/blob/main/content/en/docs/scaling/_index.md?plain=1#L242) assumes that the pod information is exposed on path `/pod/`.
As the python app already exposes it this way it seems it's easier to adapt the spring boot example.